### PR TITLE
Feat: Add binary release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,94 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to upload artifacts to (e.g. v1.0.0). Leave empty to skip upload."
+        required: false
+        default: ""
+
+jobs:
+  build:
+    name: Build ${{ matrix.os_name }}_${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            os_name: linux
+            arch: x64
+          - runner: ubuntu-24.04-arm
+            os_name: linux
+            arch: arm64
+          - runner: macos-13
+            os_name: macos
+            arch: x64
+          - runner: macos-latest
+            os_name: macos
+            arch: arm64
+          - runner: windows-latest
+            os_name: windows
+            arch: x64
+          - runner: windows-11-arm
+            os_name: windows
+            arch: arm64
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: "1.8.4"
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+
+      - name: Install PyInstaller
+        run: poetry run pip install pyinstaller
+
+      - name: Build binary
+        run: |
+          poetry run pyinstaller \
+            --onefile \
+            --name agent_runner_${{ matrix.os_name }}_${{ matrix.arch }} \
+            langchain_hello_world/main.py
+
+      - name: Upload binary as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent_runner_${{ matrix.os_name }}_${{ matrix.arch }}
+          path: dist/agent_runner_${{ matrix.os_name }}_${{ matrix.arch }}*
+          if-no-files-found: error
+
+      - name: Upload binary to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag_name }}"
+          SUFFIX=""
+          if [ "${{ matrix.os_name }}" = "windows" ]; then
+            SUFFIX=".exe"
+          fi
+          if [ -n "$TAG" ]; then
+            gh release upload "$TAG" \
+              "dist/agent_runner_${{ matrix.os_name }}_${{ matrix.arch }}${SUFFIX}" \
+              --clobber
+          else
+            echo "No release tag provided — skipping upload. Binary is available as a workflow artifact."
+          fi

--- a/docs/binary_building.md
+++ b/docs/binary_building.md
@@ -1,0 +1,116 @@
+# Building Agent Binaries
+
+This document explains how the agent is packaged into standalone executables and how to produce them locally or via CI.
+
+## Overview
+
+The agent is compiled into a single-file binary using [PyInstaller](https://pyinstaller.org). The binary bundles the Python interpreter and all dependencies, so no Python installation is required on the target machine.
+
+Binaries follow the naming convention:
+
+```
+agent_runner_{os_name}_{arch}[.exe]
+```
+
+| `os_name` | `arch` | Example |
+|-----------|--------|---------|
+| `linux`   | `x64`  | `agent_runner_linux_x64` |
+| `linux`   | `arm64`| `agent_runner_linux_arm64` |
+| `macos`   | `x64`  | `agent_runner_macos_x64` |
+| `macos`   | `arm64`| `agent_runner_macos_arm64` |
+| `windows` | `x64`  | `agent_runner_windows_x64.exe` |
+| `windows` | `arm64`| `agent_runner_windows_arm64.exe` |
+
+> **Important:** PyInstaller produces a binary for the OS and CPU architecture it runs on. To build for a different target, you must build natively on that platform — cross-compilation is not supported.
+
+---
+
+## Automated builds (CI)
+
+Binaries are built and published automatically by the [Release Binaries workflow](../.github/workflows/release.yaml) whenever a GitHub release is published.
+
+The workflow runs six parallel jobs — one per OS/arch combination — using GitHub-hosted runners:
+
+| OS | Arch | Runner |
+|----|------|--------|
+| Linux | x64 | `ubuntu-latest` |
+| Linux | arm64 | `ubuntu-24.04-arm` |
+| macOS | x64 | `macos-13` (Intel) |
+| macOS | arm64 | `macos-latest` (Apple Silicon) |
+| Windows | x64 | `windows-latest` |
+| Windows | arm64 | `windows-11-arm` |
+
+Each job:
+1. Installs Python 3.10 and Poetry 1.8.4
+2. Installs project dependencies via `poetry install`
+3. Installs PyInstaller into the Poetry virtualenv
+4. Runs PyInstaller to produce the binary under `dist/`
+5. Uploads the binary to the release as an artifact using `gh release upload`
+
+To trigger the workflow, [create a new release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) on GitHub. The binaries will appear as downloadable assets on the release page once all jobs finish.
+
+---
+
+## Building locally
+
+Follow these steps to produce a binary on your own machine.
+
+### Prerequisites
+
+- Python 3.10
+- [Poetry](https://python-poetry.org/docs/#installation) 1.8.4+
+
+### Steps
+
+```bash
+# 1. Install project dependencies
+poetry install --no-interaction --no-root
+
+# 2. Install PyInstaller
+poetry run pip install pyinstaller
+
+# 3. Build the binary (replace <os_name> and <arch> with your platform values)
+poetry run pyinstaller \
+  --onefile \
+  --name agent_runner_<os_name>_<arch> \
+  langchain_hello_world/main.py
+```
+
+The resulting binary is placed in the `dist/` directory:
+
+```
+dist/
+└── agent_runner_<os_name>_<arch>[.exe]
+```
+
+### Example — Linux x64
+
+```bash
+poetry install --no-interaction --no-root
+poetry run pip install pyinstaller
+poetry run pyinstaller --onefile --name agent_runner_linux_x64 langchain_hello_world/main.py
+./dist/agent_runner_linux_x64
+```
+
+### Example — Windows x64 (PowerShell)
+
+```powershell
+poetry install --no-interaction --no-root
+poetry run pip install pyinstaller
+poetry run pyinstaller --onefile --name agent_runner_windows_x64 langchain_hello_world/main.py
+.\dist\agent_runner_windows_x64.exe
+```
+
+---
+
+## Runtime requirements
+
+The binary is self-contained, but the agent still needs the following **environment variables** set at runtime:
+
+| Variable | Description |
+|----------|-------------|
+| `CONNECTION_CONFIGS_CONFIG_TAVILY_API_KEY` | Tavily search API key |
+| `CONNECTION_CONFIGS_CONFIG_OPENAI_API_KEY` | OpenAI API key |
+| `CONNECTION_LEDGER_CONFIG_LEDGER_APIS_GNOSIS_ADDRESS` | Gnosis RPC endpoint |
+
+These can be supplied via a `.env` file in the working directory or exported in the shell before running the binary.

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ skip_missing_interpreters = true
 
 [deps-packages]
 deps =
-    tomte[tests]==0.2.17
+    tomte[tests]==0.6.2
     open-aea[all]==1.53.0
     open-aea-cli-ipfs==1.53.0
     open-aea-ledger-ethereum==1.53.0
@@ -162,7 +162,7 @@ commands = {[commands-packages]commands}
 skipsdist = True
 skip_install = True
 deps =
-    tomte[bandit]==0.2.17
+    tomte[bandit]==0.6.2
 commands =
     bandit -s B101 -r packages/valory
     bandit -s B101 -r scripts
@@ -171,7 +171,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[black]==0.2.17
+    tomte[black]==0.6.2
 commands =
     black packages/valory scripts
 
@@ -179,7 +179,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[black]==0.2.17
+    tomte[black]==0.6.2
 commands =
     black --check packages/valory scripts
 
@@ -187,7 +187,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[isort]==0.2.17
+    tomte[isort]==0.6.2
 commands =
     isort packages/valory --gitignore
     isort scripts/
@@ -196,7 +196,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[isort]==0.2.17
+    tomte[isort]==0.6.2
 commands =
     isort --check-only --gitignore packages/valory scripts
 
@@ -256,7 +256,7 @@ skipsdist = True
 skip_install = True
 deps =
     {[deps-packages]deps}
-    tomte[docs]==0.2.17
+    tomte[docs]==0.6.2
 commands =
     {toxinidir}/scripts/generate_api_documentation.py --check-clean
 
@@ -265,7 +265,7 @@ skipsdist = True
 skip_install = True
 deps =
     {[deps-packages]deps}
-    tomte[docs]==0.2.17
+    tomte[docs]==0.6.2
 commands =
     {toxinidir}/scripts/generate_api_documentation.py
 
@@ -290,7 +290,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[docs]==0.2.17
+    tomte[docs]==0.6.2
     mkdocs-redirects
 commands =
     mkdocs build --clean --strict
@@ -299,7 +299,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[docs]==0.2.17
+    tomte[docs]==0.6.2
     mkdocs-redirects
 commands =
     mkdocs build --clean --strict
@@ -310,7 +310,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[flake8]==0.2.17
+    tomte[flake8]==0.6.2
 commands =
     flake8 packages/valory scripts
 
@@ -318,7 +318,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[mypy]==0.2.17
+    tomte[mypy]==0.6.2
 commands =
     mypy packages/valory scripts --disallow-untyped-defs --config-file tox.ini
 
@@ -327,7 +327,7 @@ whitelist_externals = /bin/sh
 skipsdist = True
 deps =
     {[deps-packages]deps}
-    tomte[pylint]==0.2.17
+    tomte[pylint]==0.6.2
 commands =
     pylint --rcfile=.pylintrc packages/valory/skills/hello_world_abci scripts -j 0
 
@@ -335,7 +335,9 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[safety]==0.2.17
+    tomte[safety]==0.6.2
+    setuptools<=81.0.0
+    marshmallow<4
 commands =
     safety check -i 37524 -i 38038 -i 37776 -i 38039 -i 39621 -i 40291 -i 39706 -i 41002 -i 51358 -i 51499 -i 67599 -i 70612
 
@@ -343,7 +345,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[vulture]==0.2.17
+    tomte[vulture]==0.6.2
 commands =
     vulture packages/valory/skills/hello_world_abci scripts/whitelist.py
 
@@ -351,7 +353,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[darglint]==0.2.17
+    tomte[darglint]==0.6.2
 commands =
     darglint scripts packages/valory/*
 
@@ -359,7 +361,7 @@ commands =
 whitelist_externals = mdspell
 skipsdist = True
 usedevelop = True
-deps = tomte[cli]==0.2.17
+deps = tomte[cli]==0.6.2
 commands = tomte check-spelling
 
 [testenv:abci-docstrings]
@@ -398,7 +400,7 @@ commands =
 [testenv:liccheck]
 skipsdist = True
 usedevelop = True
-deps = tomte[liccheck,cli]==0.2.17
+deps = tomte[liccheck,cli]==0.6.2
 commands =
     tomte freeze-dependencies --output-path {envtmpdir}/requirements.txt
     liccheck -s tox.ini -r {envtmpdir}/requirements.txt -l PARANOID


### PR DESCRIPTION
This pull request introduces a new process for building and releasing standalone agent binaries for multiple platforms. It adds a GitHub Actions workflow to automate binary builds and uploads for each OS/architecture combination and provides comprehensive documentation for both CI-based and local builds.

**Automated binary build and release:**

* Added a new GitHub Actions workflow (`.github/workflows/release.yaml`) that builds standalone agent binaries for six OS/architecture combinations (Linux x64/arm64, macOS x64/arm64, Windows x64/arm64) using PyInstaller and uploads them as release assets or workflow artifacts.

**Documentation and developer guidance:**

* Introduced `docs/binary_building.md`, which explains the binary packaging process, naming conventions, CI automation, and step-by-step instructions for building binaries locally, including prerequisites and runtime environment variable requirements.